### PR TITLE
Changed size_t to uint32_t to fix signature reading for 64-bit systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore all .txt and .mes files in the root directory
+/*.txt
+/*.mes
+
+# Don't ignore .txt and .mes files in subdirectories
+!/*/*.txt
+!/*/*.mes
+
+# Ignore executable
+/mes_tool
+
+# Ignore VSCode settings
+/.vscode/settings.json


### PR DESCRIPTION
The original code would add 8 F's to the beginning of the .mes file signature (i.e., 0xFFFFFFFFcdc3b0b0) due to platform differences.

I modified the typing in the readInt function to make it compatible, however please retest this fork on a 32-bit system to be sure. 

I've also added an error message for invalid signatures, since it took a while to figure out what was going wrong. 